### PR TITLE
modified urls for wagtail integration

### DIFF
--- a/ispa/config/urls.py
+++ b/ispa/config/urls.py
@@ -21,6 +21,7 @@ from django.conf.urls.static import static
 from wagtail.wagtailadmin import urls as wagtailadmin_urls
 from wagtail.wagtaildocs import urls as wagtaildocs_urls
 from wagtail.wagtailcore import urls as wagtail_urls
+from wagtail.wagtailsearch import urls as wagtailsearch_urls
 
 from graphene_django.views import GraphQLView
 
@@ -31,10 +32,10 @@ from ispa_app.views import AboutView, HomeView
 from events.views import EventDashboard
 
 urlpatterns = [
-    # Wagtail admin
-    url(r'^admin/', admin.site.urls),
+    # Django admin
+    url(r'^django-admin/', admin.site.urls),
     # Wagtail urls
-    url(r'^cms/', include(wagtailadmin_urls)),
+    url(r'^admin/', include(wagtailadmin_urls)),
     url(r'^documents/', include(wagtaildocs_urls)),
     url(r'^pages/', include(wagtail_urls)),
     # django-debug-toolbar
@@ -45,5 +46,6 @@ urlpatterns = [
     url(r'^events/$', EventDashboard.as_view(), name='event-view'),
     url(r'^graphql', GraphQLView.as_view(graphiql=True)),
     # Celery job api
-    url(r'^api-auth/', include('rest_framework.urls', namespace='rest_framework'))
+    url(r'^api-auth/', include('rest_framework.urls', namespace='rest_framework')),
+    url(r'', include(wagtail_urls)),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)


### PR DESCRIPTION
this branch should be called fm_wagtailconfig. please view changes to urls.py, wagtail admin is now /admin/, and django admin is now /django-admin/